### PR TITLE
Update to Electron 1.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-prebuilt-compile",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "description": "electron-prebuilt that automatically understands Babel + React + LESS",
   "bin": {
     "electron": "lib/cli.js"
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/paulcbetts/electron-prebuilt-compile",
   "dependencies": {
-    "electron": "1.4.11",
+    "electron": "1.4.12",
     "electron-compile": "*",
     "electron-compilers": "*",
     "babel-plugin-array-includes": "^2.0.3",


### PR DESCRIPTION
Electron < 1.4.12 suffers a [time-based regression](http://electron.atom.io/blog/2016/12/09/certificate-transparency-fix) for TLS certificates, so it might be better to update this ASAP.