### PR TITLE
Update to Electron 1.4.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-prebuilt-compile",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "electron-prebuilt that automatically understands Babel + React + LESS",
   "bin": {
     "electron": "lib/cli.js"
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/paulcbetts/electron-prebuilt-compile",
   "dependencies": {
-    "electron": "1.4.14",
+    "electron": "1.4.15",
     "electron-compile": "*",
     "electron-compilers": "*",
     "babel-plugin-array-includes": "^2.0.3",


### PR DESCRIPTION
This PR updates to Electron [1.4.15](https://github.com/electron/electron/releases/tag/v1.4.15).