### PR TITLE
feat(main): allow passthrough electron-compile option

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "babel-plugin-array-includes": "^2.0.3",
     "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-preset-es2016-node5": "^1.1.2",
-    "babel-preset-react": "^6.11.1"
+    "babel-preset-react": "^6.11.1",
+    "yargs": "^6.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1"

--- a/src/es6-init.js
+++ b/src/es6-init.js
@@ -18,14 +18,16 @@ function findPackageJson(initScript) {
 }
 
 function main() {
-  let initScript = path.resolve(process.argv[2]);
-  let packageJson = findPackageJson(initScript);
+  const initScript = path.resolve(process.argv[2]);
+  const packageJson = findPackageJson(initScript);
 
   // Reconstitute the original arguments
-  let args = process.argv.slice(2);
+  const args = process.argv.slice(2);
   process.argv = [process.argv[0]].concat(args);
-  
-  init(path.dirname(packageJson), initScript)
+
+  //passthrough electron-compile command args if it's specified
+  const parsedArgs = require('yargs').alias('c', 'cachedir').alias('s', 'sourcemapdir').argv;
+  init(path.dirname(packageJson), initScript, null, parsedArgs.c || null, parsedArgs.s || null);
 }
 
 main()


### PR DESCRIPTION
This PR's trying to support usecase when user installed `electron-prebuilt-compile` as drop-in replacement to `electron`, and would like to specify few init option like cachedir, sourcemapdir(not yet supported in electron compile) without having own init path. User can invoke `electron` as usual, but also able to specify cmd args like `--cachedir` to passthrough it into electron-compile's initialization.