### PR TITLE
Forward signals to child process

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,9 @@
 import electron from 'electron';
 import proc from 'child_process';
 
+const signalsToForward = ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGBREAK'];
 let params = [require.resolve('./es6-init')].concat(process.argv.slice(2));
 
 let child = proc.spawn(electron, params, {stdio: 'inherit'});
+signalsToForward.forEach((signal) => process.on(signal, () => child.kill(signal)));
 child.on('close', (code) => process.exit(code));


### PR DESCRIPTION
Fixes Electron not exiting when the CLI is spawned as a child process itself and then the parent process is killed via a signal.

Originally, running the following command and then sending a `SIGINT` to the Node process will cause Electron to remain open even through Node itself dies.

```sh
node -e 'const cp = require("child_process").spawn("node", ["./lib/cli.js", "../ELECTRON-APP"], {stdio: "inherit"});process.on("SIGINT", () => cp.kill("SIGINT"));'
```