### PR TITLE
Allow node_modules parent folders if init script is an absolute path

### DIFF
--- a/src/es6-init.js
+++ b/src/es6-init.js
@@ -10,7 +10,7 @@ function findPackageJson(initScript) {
   // Walk up the parent directories until we find package.json. Make sure that
   // we're not actually stumbling upon a parent npm package
   let ret = path.join(initScript, 'package.json')
-  if (fs.statSyncNoException(ret) && !path.resolve(path.dirname(ret), '..').match(/[\\\/]node_modules$/i)) {
+  if (_fs2.default.statSyncNoException(ret) && (initScript.startsWith("/") || !_path2.default.resolve(_path2.default.dirname(ret), '..').match(/[\\\/]node_modules$/i))) {
     return ret;
   }
 


### PR DESCRIPTION
This is in reference to Issue #39 - Don't check for a node_modules parent if init script has an absolute path. 