### PR TITLE
Filter debug protocol argument to support debugger

### DIFF
--- a/src/es6-init.js
+++ b/src/es6-init.js
@@ -18,8 +18,18 @@ function findPackageJson(initScript) {
   return findPackageJson(path.dirname(initScript));
 }
 
+/**
+ * Some debugger environment reconstruct process argument and inject args ignoring original order,
+ * extract to find out right path for init script.
+ *
+ */
+function getInitScriptPath() {
+  const rawArgv = process.argv.filter((x) => x.indexOf(`--inspect=`) === -1 && x.indexOf(`--debug-brk`))[2];
+  return path.resolve(rawArgv);
+}
+
 function main() {
-  const initScript = path.resolve(process.argv[2]);
+  const initScript = getInitScriptPath();
   const packageJson = findPackageJson(initScript);
   const packageJsonData = JSON.parse(fs.readFileSync(packageJson, 'utf8'));
 


### PR DESCRIPTION
This PR updates behavior of `es6-init` to resolve paths to init script, explicitly filtering debugger protocol argument. 

Some node.js debugger supports `--inspect` protocol, (primariliy `vscode-node-debug2` https://github.com/Microsoft/vscode-node-debug2) injects `--inspect` and `--debug-brk` for their own order and ignore original process argument specified, makes prebuild-compile fail to resolve script path. This PR simply filters them out, preserve original behavior of looking up script paths.

With this PR & latest electron (1.7.x), prebuilt-compile can use vs code config like below to debug main process.

```
{
      "type": "node",
      "request": "launch",
      "name": "Electron Main",
      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
      "args": [
        ".",
        "-r",
        "--enable-logging"
      ],
      "protocol": "inspector"
    }
```

Interestingly, source maps and others are working out of box.