### PR TITLE
Correct debug parameter exclusion

### DIFF
--- a/src/es6-init.js
+++ b/src/es6-init.js
@@ -24,7 +24,7 @@ function findPackageJson(initScript) {
  *
  */
 function getInitScriptPath() {
-  const rawArgv = process.argv.filter((x) => x.indexOf(`--inspect=`) === -1 && x.indexOf(`--debug-brk`))[2];
+  const rawArgv = process.argv.filter((x) => !(x.indexOf('--inspect') !== -1 || x.indexOf('--debug-brk') !== -1))[2];
   return path.resolve(rawArgv);
 }
 


### PR DESCRIPTION
This PR is following changes of https://github.com/electron-userland/electron-prebuilt-compile/pull/42, apply paramter filter correctly to exclude `--debug-brk` as well.