### PR TITLE
fix: work-around deprecated/removed fs.statSyncNoException (fixes #71)

### DIFF
--- a/src/es6-init.js
+++ b/src/es6-init.js
@@ -3,6 +3,16 @@ import fs from 'fs';
 import path from 'path';
 import {init} from 'electron-compile';
 
+function _statSyncNoException(fd) {
+  let result = null;
+  try {
+    result = fs.statSync(fd);
+  } catch(e) {
+  }
+
+  return result;
+}
+
 function findPackageJson(initScript) {
   if (initScript === '/' || initScript.match(/^[A-Za-z]:$/)) {
     throw new Error("Can't find package.json");
@@ -10,8 +20,8 @@ function findPackageJson(initScript) {
 
   // Walk up the parent directories until we find package.json. Make sure that
   // we're not actually stumbling upon a parent npm package
-  let ret = path.join(initScript, 'package.json')
-  if (fs.statSyncNoException(ret) && !path.resolve(path.dirname(ret), '..').match(/[\\\/]node_modules$/i)) {
+  let ret = path.join(initScript, 'package.json');
+  if (_statSyncNoException(ret) && !path.resolve(path.dirname(ret), '..').match(/[\\\/]node_modules$/i)) {
     return ret;
   }
 


### PR DESCRIPTION
This isn't an elegant fix; it just polyfills the removed function. However, that seems better to me than having it broken.

Closes #71 